### PR TITLE
fix: функция set_task принимает тип TypicalDevelopmentProgramDocumentTask

### DIFF
--- a/lib/xml/career_reserve/index.d.ts
+++ b/lib/xml/career_reserve/index.d.ts
@@ -81,7 +81,7 @@ CustomElemsBase & {
   access: XmlElem<AccessDocBase>;
   get_linked_position_common_id(): XmlElem<number> | undefined;
   assign_typical_program(typicalDevelopmentProgramId: number): void;
-  set_task(task: CareerReserveDocumentTask, typicalDevelopmentProgramId: number, parentTaskId: string): string;
+  set_task(task: TypicalDevelopmentProgramDocumentTask, typicalDevelopmentProgramId: number, parentTaskId: string): string;
   change_tutors_list(): void;
   role_id: XmlMultiElem<number>;
 };


### PR DESCRIPTION
Функция set_task в документе развития карьеры (/WebsoftServer/wtv/wtv_career_reserve.xmd) принимает тип TypicalDevelopmentProgramDocumentTask, а не CareerReserveDocumentTask как было указано ранее.
